### PR TITLE
historyResponse 변경

### DIFF
--- a/api-server/src/main/java/com/belieme/apiserver/web/responsebody/HistoryResponse.java
+++ b/api-server/src/main/java/com/belieme/apiserver/web/responsebody/HistoryResponse.java
@@ -7,7 +7,7 @@ import java.util.UUID;
 import lombok.Getter;
 
 @Getter
-@JsonPropertyOrder({"id", "univ", "dept", "item", "num", "status", "requestedAt", "requester",
+@JsonPropertyOrder({"id", "univ", "dept", "stuff", "item", "num", "status", "requestedAt", "requester",
     "approvedAt", "approveManager", "lostAt", "lostManager", "returnedAt", "returnManager",
     "canceledAt", "cancelManager"})
 public class HistoryResponse extends JsonResponse {
@@ -17,9 +17,11 @@ public class HistoryResponse extends JsonResponse {
   private UniversityResponse university;
   @JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = ResponseFilter.class)
   private DepartmentResponse department;
-
+  @JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = ResponseFilter.class)
+  private StuffResponse stuff;
   @JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = ResponseFilter.class)
   private ItemResponse item;
+
   private int num;
 
   @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -51,14 +53,15 @@ public class HistoryResponse extends JsonResponse {
   }
 
   private HistoryResponse(UUID id, UniversityResponse university, DepartmentResponse department,
-      ItemResponse item, int num, UserResponse requester, UserResponse approveManager,
-      UserResponse returnManager, UserResponse lostManager, UserResponse cancelManager,
-      long requestedAt, long approvedAt, long returnedAt, long lostAt, long canceledAt,
-      String status) {
+      StuffResponse stuff, ItemResponse item, int num, UserResponse requester,
+      UserResponse approveManager, UserResponse returnManager, UserResponse lostManager,
+      UserResponse cancelManager, long requestedAt, long approvedAt, long returnedAt, long lostAt,
+      long canceledAt, String status) {
     super(true);
     this.id = id;
     this.university = university;
     this.department = department;
+    this.stuff = stuff;
     this.item = item;
     this.num = num;
     this.requester = requester;
@@ -89,8 +92,10 @@ public class HistoryResponse extends JsonResponse {
     return new HistoryResponse(historyDto.id(),
         UniversityResponse.from(historyDto.item().stuff().department().university()),
         DepartmentResponse.from(historyDto.item().stuff().department()).withoutUniversity(),
-        ItemResponse.from(historyDto.item()).withoutUniversityAndDepartment(), historyDto.num(),
-        toNestedResponse(UserResponse.from(historyDto.requester())),
+        StuffResponse.from(historyDto.item().stuff()).withoutUniversityAndDepartment()
+            .withoutItems(),
+        ItemResponse.from(historyDto.item()).withoutUniversityAndDepartment().withoutStuffInfo(),
+        historyDto.num(), toNestedResponse(UserResponse.from(historyDto.requester())),
         toNestedResponse(UserResponse.from(historyDto.approveManager())),
         toNestedResponse(UserResponse.from(historyDto.returnManager())),
         toNestedResponse(UserResponse.from(historyDto.lostManager())),
@@ -101,15 +106,16 @@ public class HistoryResponse extends JsonResponse {
 
   public HistoryResponse withoutUniversityAndDepartment() {
     return new HistoryResponse(id, UniversityResponse.responseWillBeIgnore(),
-        DepartmentResponse.responseWillBeIgnore(), item, num, requester, approveManager,
+        DepartmentResponse.responseWillBeIgnore(), stuff, item, num, requester, approveManager,
         returnManager, lostManager, cancelManager, requestedAt, approvedAt, returnedAt, lostAt,
         canceledAt, status);
   }
 
-  public HistoryResponse withoutItem() {
-    return new HistoryResponse(id, university, department, ItemResponse.responseWillBeIgnore(), num,
-        requester, approveManager, returnManager, lostManager, cancelManager, requestedAt,
-        approvedAt, returnedAt, lostAt, canceledAt, status);
+  public HistoryResponse withoutStuffAndItem() {
+    return new HistoryResponse(id, university, department, StuffResponse.responseWillBeIgnore(),
+        ItemResponse.responseWillBeIgnore(), num, requester, approveManager, returnManager,
+        lostManager, cancelManager, requestedAt, approvedAt, returnedAt, lostAt, canceledAt,
+        status);
   }
 
   private static UserResponse toNestedResponse(UserResponse user) {

--- a/api-server/src/main/java/com/belieme/apiserver/web/responsebody/HistoryResponse.java
+++ b/api-server/src/main/java/com/belieme/apiserver/web/responsebody/HistoryResponse.java
@@ -7,7 +7,7 @@ import java.util.UUID;
 import lombok.Getter;
 
 @Getter
-@JsonPropertyOrder({"id", "univ", "dept", "stuff", "item", "num", "status", "requestedAt", "requester",
+@JsonPropertyOrder({"id", "university", "department", "stuff", "item", "num", "status", "requestedAt", "requester",
     "approvedAt", "approveManager", "lostAt", "lostManager", "returnedAt", "returnManager",
     "canceledAt", "cancelManager"})
 public class HistoryResponse extends JsonResponse {

--- a/api-server/src/main/java/com/belieme/apiserver/web/responsebody/ItemResponse.java
+++ b/api-server/src/main/java/com/belieme/apiserver/web/responsebody/ItemResponse.java
@@ -76,6 +76,6 @@ public class ItemResponse extends JsonResponse {
     if (history == null) {
       return null;
     }
-    return history.withoutItem().withoutUniversityAndDepartment();
+    return history.withoutStuffAndItem().withoutUniversityAndDepartment();
   }
 }

--- a/api-server/src/test/unit/java/com/belieme/apiserver/web/responsebody/BaseResponseTest.java
+++ b/api-server/src/test/unit/java/com/belieme/apiserver/web/responsebody/BaseResponseTest.java
@@ -179,6 +179,21 @@ public class BaseResponseTest {
     stuffInfoJsonCmpAssertions(json, stuff);
   }
 
+  protected void stuffJsonWithoutUnivAndDeptAndItemsInfoCmpAssertions(JSONObject json, StuffDto stuff) {
+    System.out.println("DTO : " + stuff);
+    System.out.println("JSON : " + json.toString());
+    System.out.println();
+
+    Assertions.assertThat(json.containsKey("university")).isFalse();
+
+    Assertions.assertThat(json.containsKey("department")).isFalse();
+
+    Assertions.assertThat(json.containsKey("items")).isFalse();
+
+    stuffInfoJsonCmpAssertions(json, stuff);
+  }
+
+
   protected void itemJsonCmpAssertions(JSONObject json, ItemDto item) {
     System.out.println("DTO : " + item);
     System.out.println("JSON : " + json.toString());
@@ -266,9 +281,13 @@ public class BaseResponseTest {
     JSONObject deptJson = (JSONObject) json.get("department");
     deptWithoutUnivJsonCmpAssertions(deptJson, history.item().stuff().department());
 
+    Assertions.assertThat(json.containsKey("stuff")).isTrue();
+    JSONObject stuffJson = (JSONObject) json.get("stuff");
+    stuffJsonWithoutUnivAndDeptAndItemsInfoCmpAssertions(stuffJson, history.item().stuff());
+
     Assertions.assertThat(json.containsKey("item")).isTrue();
     JSONObject itemJson = (JSONObject) json.get("item");
-    itemJsonWithoutUnivAndDeptInfoCmpAssertions(itemJson, history.item());
+    itemJsonWithoutUnivAndDeptAndStuffInfoCmpAssertions(itemJson, history.item());
 
     historyInfoJsonCmpAssertions(json, history);
   }
@@ -282,14 +301,18 @@ public class BaseResponseTest {
     Assertions.assertThat(json.containsKey("university")).isFalse();
     Assertions.assertThat(json.containsKey("department")).isFalse();
 
+    Assertions.assertThat(json.containsKey("stuff")).isTrue();
+    JSONObject stuffJson = (JSONObject) json.get("stuff");
+    stuffJsonWithoutUnivAndDeptAndItemsInfoCmpAssertions(stuffJson, history.item().stuff());
+
     Assertions.assertThat(json.containsKey("item")).isTrue();
     JSONObject itemJson = (JSONObject) json.get("item");
-    itemJsonWithoutUnivAndDeptInfoCmpAssertions(itemJson, history.item());
+    itemJsonWithoutUnivAndDeptAndStuffInfoCmpAssertions(itemJson, history.item());
 
     historyInfoJsonCmpAssertions(json, history);
   }
 
-  protected void historyJsonWithoutItemInfoCmpAssertions(JSONObject json, HistoryDto history) {
+  protected void historyJsonWithoutStuffAndItemInfoCmpAssertions(JSONObject json, HistoryDto history) {
     System.out.println("DTO : " + history);
     System.out.println("JSON : " + json.toString());
     System.out.println();
@@ -302,12 +325,13 @@ public class BaseResponseTest {
     JSONObject deptJson = (JSONObject) json.get("department");
     deptWithoutUnivJsonCmpAssertions(deptJson, history.item().stuff().department());
 
+    Assertions.assertThat(json.containsKey("stuff")).isFalse();
     Assertions.assertThat(json.containsKey("item")).isFalse();
 
     historyInfoJsonCmpAssertions(json, history);
   }
 
-  protected void historyJsonWithoutUnivAndDeptAndItemInfoCmpAssertions(JSONObject json,
+  protected void historyJsonWithoutUnivAndDeptAndStuffAndItemInfoCmpAssertions(JSONObject json,
       HistoryDto history) {
     System.out.println("DTO : " + history);
     System.out.println("JSON : " + json.toString());
@@ -315,6 +339,7 @@ public class BaseResponseTest {
 
     Assertions.assertThat(json.containsKey("university")).isFalse();
     Assertions.assertThat(json.containsKey("department")).isFalse();
+    Assertions.assertThat(json.containsKey("stuff")).isFalse();
     Assertions.assertThat(json.containsKey("item")).isFalse();
 
     historyInfoJsonCmpAssertions(json, history);
@@ -428,6 +453,6 @@ public class BaseResponseTest {
       Assertions.assertThat(historyJson).isNull();
       return;
     }
-    historyJsonWithoutUnivAndDeptAndItemInfoCmpAssertions(historyJson, item.lastHistory());
+    historyJsonWithoutUnivAndDeptAndStuffAndItemInfoCmpAssertions(historyJson, item.lastHistory());
   }
 }

--- a/api-server/src/test/unit/java/com/belieme/apiserver/web/responsebody/HistoryResponseTest.java
+++ b/api-server/src/test/unit/java/com/belieme/apiserver/web/responsebody/HistoryResponseTest.java
@@ -33,22 +33,22 @@ public class HistoryResponseTest extends BaseResponseTest {
   }
 
   @RepeatedTest(10)
-  @DisplayName("[-]_[`item`을 제외한 `history json serialization` 테스트]_[-]")
-  public void historyJsonWithoutStuffSerializationTest() throws IOException, ParseException {
+  @DisplayName("[-]_[`stuff`와 `item`을 제외한 `history json serialization` 테스트]_[-]")
+  public void historyJsonWithoutStuffAndItemSerializationTest() throws IOException, ParseException {
     HistoryDto history = historyGetter.randomSelect();
 
-    JSONObject json = makeJsonObject(HistoryResponse.from(history).withoutItem());
-    historyJsonWithoutItemInfoCmpAssertions(json, history);
+    JSONObject json = makeJsonObject(HistoryResponse.from(history).withoutStuffAndItem());
+    historyJsonWithoutStuffAndItemInfoCmpAssertions(json, history);
   }
 
   @RepeatedTest(10)
-  @DisplayName("[-]_[`university`와 `department`, `item`을 제외한 `history json serialization` 테스트]_[-]")
-  public void historyJsonWithoutUnivAndDeptAndStuffSerializationTest()
+  @DisplayName("[-]_[`university`와 `department`, `stuff`, `item`을 제외한 `history json serialization` 테스트]_[-]")
+  public void historyJsonWithoutUnivAndDeptAndStuffAndItemSerializationTest()
       throws IOException, ParseException {
     HistoryDto history = historyGetter.randomSelect();
 
     JSONObject json = makeJsonObject(
-        HistoryResponse.from(history).withoutUniversityAndDepartment().withoutItem());
-    historyJsonWithoutUnivAndDeptAndItemInfoCmpAssertions(json, history);
+        HistoryResponse.from(history).withoutUniversityAndDepartment().withoutStuffAndItem());
+    historyJsonWithoutUnivAndDeptAndStuffAndItemInfoCmpAssertions(json, history);
   }
 }


### PR DESCRIPTION


## Realated Issues

Fixes #95

## Summary

History response에 item 내부에 있던 stuff 정보를 밖으로 빼냄

## Check List

- [x] 혹시 main 브랜치에 merge하고 있지 않나요?

- [x] lint, prettier 까먹지는 않았나요?

- [x] 모든 test를 통과했나요?