### PR TITLE
user response 변경

### DIFF
--- a/api-server/src/main/java/com/belieme/apiserver/web/controller/UserApiController.java
+++ b/api-server/src/main/java/com/belieme/apiserver/web/controller/UserApiController.java
@@ -58,7 +58,7 @@ public class UserApiController extends BaseApiController {
   public ResponseEntity<UserResponse> getMyUserInfo(
       @RequestHeader("${api.header.user-token}") String userToken) {
     UserDto userDto = userService.getByToken(userToken);
-    UserResponse response = UserResponse.from(userDto);
+    UserResponse response = UserResponse.from(userDto).withoutSecureInfo();
     return ResponseEntity.ok(response);
   }
 

--- a/api-server/src/main/java/com/belieme/apiserver/web/responsebody/UserResponse.java
+++ b/api-server/src/main/java/com/belieme/apiserver/web/responsebody/UserResponse.java
@@ -69,6 +69,6 @@ public class UserResponse extends JsonResponse {
   }
 
   public UserResponse withoutSecureInfo() {
-    return new UserResponse(id, university, studentId, name, entranceYear, null, null, 0, 0);
+    return new UserResponse(id, university, studentId, name, entranceYear, authorities, null, 0, 0);
   }
 }

--- a/api-server/src/test/unit/java/com/belieme/apiserver/web/responsebody/BaseResponseTest.java
+++ b/api-server/src/test/unit/java/com/belieme/apiserver/web/responsebody/BaseResponseTest.java
@@ -113,7 +113,13 @@ public class BaseResponseTest {
     JSONObject univJson = (JSONObject) json.get("university");
     basicUnivJsonCmpAssertions(univJson, user.university());
 
-    Assertions.assertThat(json.containsKey("authorities")).isFalse();
+    Assertions.assertThat(json.containsKey("authorities")).isTrue();
+    JSONArray jsonArray = (JSONArray) json.get("authorities");
+    for (int i = 0; i < jsonArray.size(); i++) {
+      JSONObject authorityJson = (JSONObject) jsonArray.get(i);
+      authorityJsonCmpAssertions(authorityJson, user.meaningfulAuthorities().get(i));
+    }
+
     Assertions.assertThat(json.containsKey("token")).isFalse();
     Assertions.assertThat(json.containsKey("createdAt")).isFalse();
     Assertions.assertThat(json.containsKey("approvedAt")).isFalse();


### PR DESCRIPTION

## Realated Issues

Fixes #97

## Summary

secureInfo를 제거한 userResponse에 authorities 정보를 추가하고 내 정보 불러오는 api response에 secureInfo 제거

## Check List

- [x] 혹시 main 브랜치에 merge하고 있지 않나요?

- [x] lint, prettier 까먹지는 않았나요?

- [x] 모든 test를 통과했나요?